### PR TITLE
Update BinaryHeapStrategy.ts

### DIFF
--- a/src/BinaryHeapStrategy.ts
+++ b/src/BinaryHeapStrategy.ts
@@ -42,7 +42,7 @@ export default class BinaryHeapStrategy<T> implements QueueStrategy<T> {
         this.data.length = 0;
     }
 
-    public _bubbleUp(pos: number) {
+    public _bubbleUp(pos: number): any {
         while (pos > 0) {
             const parent = (pos - 1) >>> 1;
             if (this.comparator(this.data[pos], this.data[parent]) < 0) {


### PR DESCRIPTION
Hi! Run into the following issue:

```
node_modules/ts-priority-queue/src/BinaryHeapStrategy.ts:60:12 - error TS7010: '_bubbleDown', which lacks return-type annotation, implicitly has an 'any' return type.
60     public _bubbleDown(pos: number) {
              ~~~~~~~~~~~
```
This PR fixes it.